### PR TITLE
Added Logging Methods

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,7 @@
-package stdlib
+// Package log with formatted messages to an output based on type.
+// Defaults to stdout and Err
+// stderr.
+package log
 
 import (
 	"fmt"
@@ -17,50 +20,32 @@ const (
 // VerbosityLevel Logging level (default=3); 0=fatal,1=error,2=warning,3=general,4=info,5=debug
 var VerbosityLevel = VerboseLvlLog
 
-// Dbugf Print a debug message to stdout.`
-//
-// Deprecated: This was moved to the log package, please use log.Dbugf instead.
-// This will be removed in the next major release.
+// Dbugf Print a debug message to stdout.
 func Dbugf(message string, vars ...interface{}) {
 	verboseF(VerboseLvlDebug, message, vars...)
 }
 
 // Errf Print a warning message to stderr.
-//
-// Deprecated: This was moved to the log package, please use log.Errf instead.
-// This will be removed in the next major release.
 func Errf(message string, vars ...interface{}) {
 	verboseF(VerboseLvlError, message, vars...)
 }
 
 // Fatf Print a fatal message to stderr.
-//
-// Deprecated: This was moved to the log package, please use log.Fatf instead.
-// This will be removed in the next major release.
 func Fatf(message string, vars ...interface{}) {
 	verboseF(VerboseLvlFatal, message, vars...)
 }
 
 // Infof Print an informational message to stdout.
-//
-// Deprecated: This was moved to the log package, please use log.Infof instead.
-// This will be removed in the next major release.
 func Infof(message string, vars ...interface{}) {
 	verboseF(VerboseLvlInfo, message, vars...)
 }
 
 // Logf Log a general message, useful for giving the user feedback on progress.
-//
-// Deprecated: This was moved to the log package, please use log.Logf instead
-// This will be removed in the next major release.
 func Logf(message string, vars ...interface{}) {
 	verboseF(VerboseLvlLog, message, vars...)
 }
 
 // Warnf Print a warning message to stdout.
-//
-// Deprecated: This was moved to the log package, please use log.Warnf instead.
-// This will be removed in the next major release.
 func Warnf(message string, vars ...interface{}) {
 	verboseF(VerboseLvlWarn, message, vars...)
 }


### PR DESCRIPTION
Moved the logging functionality to its own package, but kept the existing functions in place until the next major release. The scale for logging has changed, fatal is now 1 ending with debug at 6. Which ensures that fatal, error, and warnings are always displayed when the level is set to general logging. This makes more sense, now you do not have to turn logging all the way up just to see fatal and error messages as with the scale before.

## Fixed

* All Logging methods are accessible through the API.

## Added

* New log Package.

## Changed

* Verbosity Level Scale: Logging level (default=3); 0=fatal,1=error,2=warning,3=general,4=info,5=debug.
