### PR TITLE
Fixed File Extension Checker File Handling

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -3,7 +3,7 @@ package stdlib
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -64,28 +64,32 @@ func DirExist(path string) bool {
 	return true
 }
 
-// IsValid Returns true for files that match allowed extensions.
-func (fec *FileExtChecker) IsValid(file string) (ret bool) {
-	ret = false
-
-	ext := strings.Trim(path.Ext(file), ".")
+// IsValid Returns true for files that match allowed or excluded extensions.
+// Passing a full path only checks the basename.
+// Default to include all files.
+// If a file has no extension, then use its basename.
+func (fec *FileExtChecker) IsValid(file string) bool {
+	basename := filepath.Base(file) // account for hidden directories
+	ext := strings.Trim(filepath.Ext(basename), ".")
+	// when there is no extension (unix/linux/mac) use the basename
+	if len(ext) == 0 && len(basename) > 1 {
+		ext = basename
+	}
 
 	if ext != "" {
 		for _, t := range *fec.excludes {
-			ret = true
 			if t == ext {
 				return false
 			}
 		}
 		for _, t := range *fec.includes {
 			if t == ext {
-				ret = true
-				break
+				return true
 			}
 		}
 	}
 
-	return
+	return true
 }
 
 // PathExist true for a directory/file and false otherwise.

--- a/stdlib_test.go
+++ b/stdlib_test.go
@@ -28,22 +28,23 @@ func TestPathExist(runner *testing.T) {
 }
 
 func TestIsTextFile(tester *testing.T) {
-
 	cases := []struct {
 		name, path string
 		want       bool
 	}{
-		{"IsATextFile", "text-file-01.txt", true},
-		{"notATextFile", "text-file-02.jpg", false},
-		{"notATextFile", "text-file-03.gif", false},
-		{"notATextFile", "text-file-04.png", false},
-		{"notATextFile", "text-file-05.json", true},
-		{"notATextFile", "text-file-06.md", true},
-		{"notATextFile", "text-file-07.xml", true},
+		{"txt", "text-file-01.txt", true},
+		{"jpg", "text-file-02.jpg", false},
+		{"gif", "text-file-03.gif", false},
+		{"png", "text-file-04.png", false},
+		{"json", "text-file-05.json", true},
+		{"md", "text-file-06.md", true},
+		{"xml", "text-file-07.xml", true},
+		{"hiddenDirectory", ".hidden/file.txt", true},
+		{"noExtension", "config", true},
 	}
 
 	el := []string{"jpg", "gif", "png", "pdf"}
-	in := []string{"txt", "json", "md", "xml"}
+	in := []string{"txt", "json", "md", "xml", "config"}
 	sbj, _ := NewFileExtChecker(&el, &in)
 
 	for _, fxtr := range cases {
@@ -66,25 +67,6 @@ func TestIsTextFile(tester *testing.T) {
 	fxtr := cases[0]
 	el = []string{"jpg", "gif", "png", "pdf"}
 	in = []string{}
-	sbj, _ = NewFileExtChecker(&el, &in)
-	tester.Run(fxtr.name, func(t *testing.T) {
-
-		got := sbj.IsValid(fxtr.path)
-
-		if got != fxtr.want {
-			t.Errorf("got %v, want %v, for %v", got, fxtr.want, fxtr.path)
-		}
-	})
-
-	cases = []struct {
-		name, path string
-		want       bool
-	}{
-		{"notInTheIncludeList", "file-07.jpg", false},
-	}
-	fxtr = cases[0]
-	el = []string{}
-	in = []string{"txt", "json", "md", "xml"}
 	sbj, _ = NewFileExtChecker(&el, &in)
 	tester.Run(fxtr.name, func(t *testing.T) {
 


### PR DESCRIPTION
Improve handling of passing the file checker full paths, hidden directories, and default to include all files so only an exclusion list is needed. Also if a file has no extension, then use its basename.