### PR TITLE
Rewrite cli Package Run Command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,33 +1,44 @@
 package cli
 
 import (
-	"github.com/kohirens/stdlib/log"
 	"os"
 	"os/exec"
 	"strings"
 )
 
-type CommandRunner func(program, workDir string, args ...string) (cmdOut []byte, cmdErr error, exitCode int)
+type CommandRunner func(wd, program string, args ...string) (cmdOut []byte, cmdErr error, exitCode int, cmdStr string)
+type CommandRunnerWithInput func(wd, program string, args ...string) (cmdOut []byte, cmdErr error, exitCode int, cmdStr string)
+type CommandRunnerWithInputAndEnv func(wd, program string, args ...string) (cmdOut []byte, cmdErr error, exitCode int, cmdStr string)
 
 // RunCommand run an external program in a sub process.
-func RunCommand(
-	workDir, program string,
+func RunCommand(wd, program string, args []string) (cmdOut []byte, cmdErr error, exitCode int, cmdStr string) {
+	return RunCommandWithInputAndEnv(wd, program, args, nil, nil)
+}
+
+// RunCommandWithInput run an external program in a sub process, allowing with
+// input.
+func RunCommandWithInput(wd string, program string, args []string, input []byte) (cmdOut []byte, cmdErr error, exitCode int, cmdStr string) {
+	return RunCommandWithInputAndEnv(wd, program, args, input, nil)
+}
+
+// RunCommandWithInputAndEnv run an external program in a sub process, with
+// input and setting environment variables in the sub process. It
+// will pass in the os.Environ(), overwriting key=value pairs from env map,
+// comparison for the key (variable name) is case-sensitive.
+func RunCommandWithInputAndEnv(
+	wd,
+	program string,
 	args []string,
-	env map[string]string,
 	input []byte,
-) (cmdOut []byte, cmdErr error, exitCode int) {
+	env map[string]string,
+) (cmdOut []byte, cmdErr error, exitCode int, cmdStr string) {
 	cmd := exec.Command(program, args...)
-	cmd.Dir = workDir
+	cmd.Dir = wd
 	ce := os.Environ()
 
+	// overwrite or set environment variables
 	if env != nil {
-		for i, kv := range ce {
-			p := strings.Split(kv, "=")
-			v, ok := env[p[0]]
-			if ok {
-				ce[i] = p[0] + "=" + v
-			}
-		}
+		ce = AmendStringAry(ce, env)
 	}
 
 	cmd.Env = ce
@@ -35,7 +46,7 @@ func RunCommand(
 	if input != nil {
 		cmdIn, err1 := cmd.StdinPipe()
 		if err1 != nil {
-			return []byte{}, err1, 1
+			return []byte{}, err1, 1, ""
 		}
 
 		defer func() {
@@ -45,14 +56,38 @@ func RunCommand(
 		// write the input
 		_, err2 := cmdIn.Write(input)
 		if err2 != nil {
-			return []byte{}, err1, 1
+			return []byte{}, err1, 1, ""
 		}
 	}
 
 	cmdOut, cmdErr = cmd.CombinedOutput()
 	exitCode = cmd.ProcessState.ExitCode()
-
-	log.Infof("sub command run: %q", cmd.String())
+	cmdStr = cmd.String()
 
 	return
+}
+
+// AmendStringAry where []string (like os.Environ()) is string of key=value
+// pairs. Pass in a map who's that will overwrite an existing key pair, or append it to the string array.
+func AmendStringAry(ce []string, env map[string]string) []string {
+	for key, val := range env {
+		found := false
+		idx := -1
+		for i, pair := range ce {
+			p := strings.Split(pair, "=")
+			k := p[0]
+			if key == k {
+				found = true
+				idx = i
+				break
+			}
+		}
+		newPair := key + "=" + val
+		if found { //overwrite
+			ce[idx] = newPair
+		} else { //append
+			ce = append(ce, newPair)
+		}
+	}
+	return ce
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestAmendStringAry(t *testing.T) {
+	tests := []struct {
+		name string
+		ce   []string
+		env  map[string]string
+		want []string
+	}{
+		{
+			"overwriteAndAmend",
+			[]string{"GOARCH=amd64", "GOOS=windows"},
+			map[string]string{"GOOS": "linux", "test": "1234"},
+			[]string{"GOARCH=amd64", "GOOS=linux", "test=1234"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AmendStringAry(tt.ce, tt.env)
+			if got[0] != tt.want[0] {
+				t.Errorf("AmendStringAry()[0] = %v, want %v", got[0], tt.want[0])
+			}
+			if got[1] != tt.want[1] {
+				t.Errorf("AmendStringAry()[1] = %v, want %v", got[1], tt.want[1])
+			}
+			if got[2] != tt.want[2] {
+				t.Errorf("AmendStringAry()[2] = %v, want %v", got[2], tt.want[2])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added RunCommandWithInputAndEnv to the cli package. Which will allow passing in input and overwriting the environment variables in the sub process.

Complementary command runner types were added for all run command variants.

Parameter order and names were changed and added a return value to all command runner types and command runner functions; which constitutes a breaking change.