### PR TITLE
Added Usage Function

### DIFF
--- a/cli/flag.go
+++ b/cli/flag.go
@@ -1,5 +1,12 @@
 package cli
 
+import (
+	"flag"
+	"fmt"
+	"os"
+	"text/template"
+)
+
 type BoolFlag struct {
 	Name string
 	Def  string
@@ -21,11 +28,74 @@ type StrFlag struct {
 	Val  string
 }
 
-const UsageTmpl = `
-{{define "option"}}
+var UsageTmpl = `
+{{- define "option"}}
 {{printf "  -%-11s %v" .option .info}}{{with .dv }} (default = {{.}}){{end}}
 {{end}}
+{{- define "subcommand"}}
+{{printf "%-14s %v" .command .summary}}
+{{end}}
+
 Usage: {{ .appName }} [subcommand] -[options] <args>
 
 Options:
 `
+
+// Usage Print the usage documentation.
+func Usage(appName string, um map[string]string, subcommands map[string]*flag.FlagSet) error {
+	tmpl, err1 := template.New("Usage").Parse(UsageTmpl)
+	if err1 != nil {
+		return fmt.Errorf(stderr.UsageTmplParse, err1.Error())
+	}
+
+	uTmplData := map[string]string{
+		"appName": appName,
+	}
+
+	if e := tmpl.Execute(os.Stdout, uTmplData); e != nil {
+		return fmt.Errorf(stderr.UsageTmplExecute, e.Error())
+	}
+
+	var err2 error
+	flag.VisitAll(func(f *flag.Flag) { // global flags
+		m, ok := um[f.Name]
+		if ok {
+			td := map[string]string{
+				"option": f.Name, "info": m, "dv": f.Value.String(),
+			}
+
+			if e := tmpl.ExecuteTemplate(os.Stdout, "option", td); e != nil {
+				err2 = e
+				return
+			}
+		}
+	})
+
+	for command, flagSet := range subcommands {
+		td := map[string]string{
+			"command": command, "summary": um[command],
+		}
+		if e := tmpl.ExecuteTemplate(os.Stdout, "subcommand", td); e != nil {
+			err2 = e
+			break
+		}
+
+		flagSet.VisitAll(func(f *flag.Flag) { // global flags
+			m, ok := um[command+"_"+f.Name]
+			if ok {
+				td = map[string]string{
+					"option": f.Name, "info": m, "dv": f.Value.String(),
+				}
+				if e := tmpl.ExecuteTemplate(os.Stdout, "option", td); e != nil {
+					err2 = e
+					return
+				}
+			}
+		})
+		if err2 != nil {
+			break
+		}
+	}
+
+	return err2
+}

--- a/cli/message.go
+++ b/cli/message.go
@@ -1,0 +1,9 @@
+package cli
+
+var stderr = struct {
+	UsageTmplParse   string
+	UsageTmplExecute string
+}{
+	UsageTmplParse:   "error parsing the Usage template: %v",
+	UsageTmplExecute: "error executing the Usage template %v",
+}


### PR DESCRIPTION
Gives just a bit more than the out-of-the-box flag.Print function.

* Global usage header.
* Subcommands with summary and options.
* Changed UsageTmpl from a constant to a variable, so it can be customized to fit the apps needs.