### PR TITLE
Patch update 2024 01 31

### DIFF
--- a/web/content.go
+++ b/web/content.go
@@ -1,7 +1,7 @@
 package web
 
 const (
-	Http200Debug                = `<!DOCTYPE html><html><head><title>Debugging Implemented</title></head><body><center><h1>Debugging is currently Implemented</h1></center><hr><center>Lambda</center></body></html>`
+	Http200Debug                = `<!DOCTYPE html><html><head><title>Debugging Implemented (%[1]d)</title></head><body style="text-align:center"><h1>Debugging is currently Implemented</h1><p>%[2]v</p><div>%[3]v</div></body></html>`
 	Http301RedirectContent      = `<!DOCTYPE html><html><head><title>301 Moved Permanently</title></head><body><center><h1>301 Moved Permanently</h1></center><hr><center>CloudFront</center></body></html>`
 	Http308RedirectContent      = `<!DOCTYPE html><html><head><title>308 Permanent Redirect</title></head><body><center><h1>308 Permanent Redirect</h1></center><hr><center>CloudFront</center></body></html>`
 	Http401UnauthorizedContent  = `<!DOCTYPE html><html><head><title>401 Unauthorized</title></head><body><center><h1>401 Unauthorized</h1></center><hr><center>CloudFront</center></body></html>`

--- a/web/content.go
+++ b/web/content.go
@@ -8,6 +8,7 @@ const (
 	Http404NotFoundContent      = `<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><center><h1>404 Not Found</h1></center><hr><center>CloudFront</center></body></html>`
 	Http500InternalErrorContent = `<!DOCTYPE html><html><head><title>500 Internal Server Error</title></head><body><center><h1>500 Internal Server Error</h1></center><hr><center>CloudFront</center></body></html>`
 	Http501NotImplemented       = `<!DOCTYPE html><html><head><title>501 Not Implemented</title></head><body><center><h1>501 Not Implemented</h1></center><hr><center>CloudFront</center></body></html>`
+	HttpRedirectContent         = `<!DOCTYPE html><html><head><title>%[1]v %[2]v</title></head><body><center><h1>%[1]v %[2]v</h1><hr>%[3]vCloudFront</center></body></html>`
 
 	// See [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml)
 	// Also see [IETF Media Types](https://www.rfc-editor.org/rfc/rfc9110.html#media.type)

--- a/web/page.go
+++ b/web/page.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kohirens/stdlib/log"
+	"net/http"
 	"path/filepath"
 	"strings"
 )
@@ -112,6 +113,7 @@ func Respond200(content []byte, contentType string) *Response {
 }
 
 // Respond301Or308 Send a 301 or 308 HTTP response redirect to another location.
+// Deprecated see Respond301 or Respond308
 func Respond301Or308(method, location string) *Response {
 	code := 301
 	content := Http301RedirectContent
@@ -132,6 +134,44 @@ func Respond301Or308(method, location string) *Response {
 			"Location":     location,
 		},
 		StatusCode: code,
+	}
+}
+
+const Footer = "Acme"
+
+// Respond301 Send a 301 HTTP response redirect to another location (full URL).
+func Respond301(location string) *Response {
+	return &Response{
+		Body: fmt.Sprintf(HttpRedirectContent, http.StatusMovedPermanently, "Moved Permanently", Footer),
+		Headers: StringMap{
+			"Content-Type": ContentTypeHtml,
+			"Location":     location,
+		},
+		StatusCode: http.StatusMovedPermanently,
+	}
+}
+
+// Respond302 Send a 302 HTTP response redirect to another location (full URL).
+func Respond302(location string) *Response {
+	return &Response{
+		Body: fmt.Sprintf(HttpRedirectContent, http.StatusFound, "Found", Footer),
+		Headers: StringMap{
+			"Content-Type": ContentTypeHtml,
+			"Location":     location,
+		},
+		StatusCode: http.StatusFound,
+	}
+}
+
+// Respond308 Send a 308 HTTP response redirect to another location (full URL).
+func Respond308(location string) *Response {
+	return &Response{
+		Body: fmt.Sprintf(HttpRedirectContent, http.StatusPermanentRedirect, "Permanent Redirect", Footer),
+		Headers: StringMap{
+			"Content-Type": ContentTypeHtml,
+			"Location":     location,
+		},
+		StatusCode: http.StatusPermanentRedirect,
 	}
 }
 

--- a/web/page.go
+++ b/web/page.go
@@ -224,6 +224,20 @@ func Response501() *Response {
 	}
 }
 
+// RespondDebug Respond with a debug message and whatever code your like.
+//
+//	This was handy when testing AWS Lambda function or initial set up of the
+//	Lambda URL feature.
+func RespondDebug(code int, message, footer string) *Response {
+	return &Response{
+		Body: fmt.Sprintf(Http200Debug, code, message, footer),
+		Headers: StringMap{
+			"Content-Type": ContentTypeHtml,
+		},
+		StatusCode: code,
+	}
+}
+
 // RespondJSON Send a JSON HTTP response.
 func RespondJSON(content interface{}) (*Response, error) {
 	jsonEncodedContent, e1 := json.Marshal(content)

--- a/web/page.go
+++ b/web/page.go
@@ -208,13 +208,13 @@ func Respond500() *Response {
 	}
 }
 
-// Response501 Send a 501 Not Implemented HTTP response.
+// Respond501 Send a 501 Not Implemented HTTP response.
 //
 //	501 is the appropriate response when the server does not recognize the
 //	request method and is incapable of supporting it for any resource. The only
 //	methods that servers are required to support (and therefore that must not
 //	return 501) are GET and HEAD.
-func Response501() *Response {
+func Respond501() *Response {
 	return &Response{
 		Body: Http501NotImplemented,
 		Headers: StringMap{

--- a/web/page_test.go
+++ b/web/page_test.go
@@ -123,6 +123,7 @@ func TestRespond301Or308(t *testing.T) {
 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501
 func TestRespond401(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -133,6 +134,7 @@ func TestRespond401(t *testing.T) {
 		{"401", Respond401, 401, 401},
 		{"404", Respond404, 404, 404},
 		{"500", Respond500, 500, 500},
+		{"500", Respond501, 501, 501},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/web/page_test.go
+++ b/web/page_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"reflect"
 	"strings"
@@ -173,6 +174,35 @@ func TestRespondJSONOG(t *testing.T) {
 
 			if got.Body != tt.wantBody {
 				t.Errorf("RespondJSON() = %v, want %v", got.Body, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestRespondDebug(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		footer  string
+		code    int
+	}{
+		{"Debug200", "status ok", "Acme", 401},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RespondDebug(tt.code, tt.message, tt.footer)
+
+			if !strings.Contains(got.Body, fmt.Sprintf("%v", tt.code)) {
+				t.Errorf("RespondDebug() = does not contain %v", tt.code)
+			}
+
+			if !strings.Contains(got.Body, fmt.Sprintf("%v", tt.message)) {
+				t.Errorf("RespondDebug() = does not contain %v", tt.footer)
+			}
+
+			if !strings.Contains(got.Body, fmt.Sprintf("%v", tt.footer)) {
+				t.Errorf("RespondDebug() = does not contain %v", tt.footer)
 			}
 		})
 	}


### PR DESCRIPTION
## Fixed

* Web 501 Response Function Name - It was incorrectly named Response501, it was corrected to the name Respond501.

## Added

* Web Debug Responder - Allows you to set an HTTP response with a desired HTTP code and message.
* Individual Web Response Redirect Methods - Added Respond301, Respond302, and Respond308. The Respond301Or308 has been deprecated. Also the response body content has been removed.